### PR TITLE
chore: fix deprecation warning for whitelist rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
   plugins: ['stylelint-performance-animation'],
   rules: {
     'plugin/no-low-performance-animation': true,
-    'at-rule-whitelist': [
+    'at-rule-allowed-list': [
       'extend',
       'keyframes',
       'import',


### PR DESCRIPTION
Fix deprecation warning

https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/at-rule-whitelist/README.m

<img width="965" alt="Screen Shot 2021-06-22 at 8 04 12 PM" src="https://user-images.githubusercontent.com/14832910/123014829-0e64b180-d395-11eb-8873-a8b73d2c8ca8.png">
