### PR TITLE
chore: add scss use rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,12 +17,13 @@ module.exports = {
       'if',
       'media',
       'page',
-      'content'
+      'content',
+      'use'
     ],
     'at-rule-no-unknown': [
       true,
       {
-        ignoreAtRules: ['function', 'if', 'else', 'for', 'each', 'include', 'mixin', 'return']
+        ignoreAtRules: ['function', 'if', 'else', 'for', 'each', 'include', 'mixin', 'return', 'use']
       }
     ],
     'color-no-invalid-hex': true,


### PR DESCRIPTION
We need to support `@use` so we can use `@use 'sass:math'`  since I want to add it to our generator in this [PR #205] (https://github.com/Jam3/nextjs-boilerplate/pull/205) to avoid adding this to all projects

<img width="637" alt="Screen Shot 2022-02-09 at 8 17 29 PM" src="https://user-images.githubusercontent.com/14832910/153321146-7b269eca-377f-4868-9a30-cf41238dc52a.png">
